### PR TITLE
Persist overlay state per streamer

### DIFF
--- a/db.js
+++ b/db.js
@@ -199,6 +199,16 @@ CREATE TABLE IF NOT EXISTS streamers (
 );
 `);
 
+// 7) Таблица для хранения оверлейного состояния стримеров
+db.exec(`
+CREATE TABLE IF NOT EXISTS streamer_overlay_state (
+  streamer_id TEXT PRIMARY KEY,
+  state_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  FOREIGN KEY(streamer_id) REFERENCES users(twitch_user_id) ON DELETE CASCADE
+);
+`);
+
 // 7) Индекс для быстрого поиска по da_user_id
 db.exec(`CREATE INDEX IF NOT EXISTS idx_streamers_da_user_id ON streamers(da_user_id);`);
 
@@ -989,7 +999,7 @@ function updateGiftInfo(giftType, giftId, name, description) {
   try {
     const now = Date.now();
     const giftIdStr = `gift_${giftType}_${giftId}`;
-    
+
     const existing = db.prepare(`SELECT id FROM gifts WHERE id = ?`).get(giftIdStr);
     
     if (existing) {
@@ -1010,6 +1020,52 @@ function updateGiftInfo(giftType, giftId, name, description) {
     return true;
   } catch (error) {
     console.error('Error updating gift info:', error);
+    return false;
+  }
+}
+
+function getStreamerOverlayState(streamerId) {
+  if (!streamerId) {
+    return null;
+  }
+
+  try {
+    const row = db.prepare(`
+      SELECT state_json
+      FROM streamer_overlay_state
+      WHERE streamer_id = ?
+    `).get(streamerId);
+
+    if (!row || !row.state_json) {
+      return null;
+    }
+
+    return JSON.parse(row.state_json);
+  } catch (error) {
+    console.error('Error loading overlay state:', error);
+    return null;
+  }
+}
+
+function setStreamerOverlayState(streamerId, state) {
+  if (!streamerId) {
+    throw new Error('streamerId is required to save overlay state');
+  }
+
+  try {
+    const payload = JSON.stringify(state || {});
+    const now = Date.now();
+
+    db.prepare(`
+      INSERT INTO streamer_overlay_state (streamer_id, state_json, updated_at)
+      VALUES (?, ?, ?)
+      ON CONFLICT(streamer_id)
+      DO UPDATE SET state_json = excluded.state_json, updated_at = excluded.updated_at
+    `).run(streamerId, payload, now);
+
+    return true;
+  } catch (error) {
+    console.error('Error saving overlay state:', error);
     return false;
   }
 }
@@ -1061,6 +1117,8 @@ module.exports = {
   getGiftInfo,
   getAllGifts,
   updateGiftInfo,
+  getStreamerOverlayState,
+  setStreamerOverlayState,
   GIFT_TYPES,
   GIFT_IDS,
   db

--- a/lib/donationalerts-poll.js
+++ b/lib/donationalerts-poll.js
@@ -173,14 +173,14 @@ async function processDonation(streamerId, donation) {
     // Добавляем аватар в активный список ПОСЛЕ отправки событий (как в команде !start)
     const { addActiveAvatar, removeActiveAvatar } = require('../services/bot');
     try {
-      addActiveAvatar(user.twitch_user_id);
+      addActiveAvatar(streamerId, user.twitch_user_id);
       console.log(`[DA Poll] Added avatar ${user.twitch_user_id} to active list for chat monitoring`);
       
       // Автоматически удаляем аватар из активного списка через 5 минут
       // (аватар может остаться в overlay, но перестанет реагировать на сообщения)
       setTimeout(() => {
         try {
-          removeActiveAvatar(user.twitch_user_id);
+          removeActiveAvatar(streamerId, user.twitch_user_id);
           console.log(`[DA Poll] Auto-removed avatar ${user.twitch_user_id} from active list after timeout`);
         } catch (error) {
           console.error(`[DA Poll] Error auto-removing avatar from active list: ${error.message}`);

--- a/routes/bot.js
+++ b/routes/bot.js
@@ -6,13 +6,13 @@ function registerBotRoutes(app) {
     try {
       const uid = req.cookies.uid;
       if (!uid) return res.status(401).send('Неизвестен пользователь (нет cookie uid)');
-      
-      // Check if bot is already running
-      const botStatus = status();
+
+      // Check if bot is already running for this streamer
+      const botStatus = status(uid);
       if (botStatus.running) {
         return res.status(400).send('Бот уже подключен! Сначала остановите текущего бота.');
       }
-      
+
       const { profile } = await ensureBotFor(String(uid));
       res.status(200).send(`✅ Бот успешно запущен и подключён к #${profile.login}. Напиши в чате "!ping" — ответит "pong".`);
     } catch (e) {
@@ -21,9 +21,12 @@ function registerBotRoutes(app) {
     }
   });
 
-  app.post('/bot/stop', async (_req, res) => {
+  app.post('/bot/stop', async (req, res) => {
     try {
-      const changed = await stopBot();
+      const uid = req.cookies.uid;
+      if (!uid) return res.status(401).send('Неизвестен пользователь (нет cookie uid)');
+
+      const changed = await stopBot(String(uid));
       if (!changed) return res.status(200).send('Бот уже остановлен.');
       res.status(200).send('Бот остановлен.');
     } catch (e) {
@@ -32,8 +35,12 @@ function registerBotRoutes(app) {
     }
   });
 
-  app.get('/bot/status', (_req, res) => {
-    res.json(status());
+  app.get('/bot/status', (req, res) => {
+    const uid = req.cookies.uid;
+    if (!uid) {
+      return res.json(status());
+    }
+    res.json(status(String(uid)));
   });
 }
 

--- a/routes/logout.js
+++ b/routes/logout.js
@@ -6,11 +6,13 @@ function registerLogoutRoute(app) {
     res.clearCookie('uid');
     res.cookie('force_login', '1', { httpOnly: true, sameSite: 'lax' });
     try {
-      const st = status();
-      if (st.running && st.for_user && uid && String(uid) === String(st.for_user)) {
-        try { await stopBot(); } catch(_) {}
+      if (uid) {
+        const st = status(String(uid));
+        if (st.running) {
+          try { await stopBot(String(uid)); } catch (_) {}
+        }
       }
-    } catch(_) {}
+    } catch (_) {}
     res.status(200).send('ok');
   });
 }

--- a/services/bot/index.js
+++ b/services/bot/index.js
@@ -1,0 +1,241 @@
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+
+const SINGLE_BOT_PATH = path.join(__dirname, 'single.js');
+const singleBotSource = fs.readFileSync(SINGLE_BOT_PATH, 'utf8');
+
+const instances = new Map();
+
+function createInstance(streamerId) {
+  const moduleFilename = `${SINGLE_BOT_PATH}?uid=${streamerId}`;
+  const botModule = new Module(moduleFilename, module.parent);
+  botModule.filename = moduleFilename;
+  botModule.paths = Module._nodeModulePaths(path.dirname(SINGLE_BOT_PATH));
+  botModule._compile(singleBotSource, moduleFilename);
+  return botModule.exports;
+}
+
+function getInstance(streamerId) {
+  if (!streamerId) {
+    throw new Error('streamerId is required');
+  }
+
+  let instance = instances.get(streamerId);
+  if (!instance) {
+    instance = createInstance(streamerId);
+    instances.set(streamerId, instance);
+  }
+  return instance;
+}
+
+function getExistingInstance(streamerId) {
+  return instances.get(streamerId);
+}
+
+async function ensureBotFor(streamerId) {
+  const instance = getInstance(streamerId);
+  return instance.ensureBotFor(streamerId);
+}
+
+async function stopBot(streamerId) {
+  if (!streamerId) {
+    const ids = Array.from(instances.keys());
+    const results = await Promise.all(ids.map(async id => {
+      const inst = instances.get(id);
+      if (!inst) return false;
+      const stopped = await inst.stopBot();
+      if (stopped) {
+        instances.delete(id);
+      }
+      return stopped;
+    }));
+    return results.some(Boolean);
+  }
+
+  const instance = getExistingInstance(streamerId);
+  if (!instance) {
+    return false;
+  }
+  const stopped = await instance.stopBot();
+  if (stopped) {
+    instances.delete(streamerId);
+  }
+  return stopped;
+}
+
+function status(streamerId) {
+  if (streamerId) {
+    const instance = getExistingInstance(streamerId);
+    return instance ? instance.status() : { streamerId, running: false };
+  }
+
+  const bots = {};
+  for (const [id, inst] of instances.entries()) {
+    bots[id] = inst.status();
+  }
+  return {
+    running: instances.size > 0,
+    bots
+  };
+}
+
+function proxyCall(streamerId, method, args, optional = false) {
+  const instance = optional ? getExistingInstance(streamerId) : getInstance(streamerId);
+  if (!instance) {
+    return null;
+  }
+  const fn = instance[method];
+  if (typeof fn !== 'function') {
+    throw new Error(`Method ${method} is not available on bot instance`);
+  }
+  return fn(...args);
+}
+
+function getBotClient(streamerId) {
+  return proxyCall(streamerId, 'getBotClient', [], true);
+}
+
+function getBotChannel(streamerId) {
+  return proxyCall(streamerId, 'getBotChannel', [], true);
+}
+
+function addActiveAvatar(streamerId, userId) {
+  return proxyCall(streamerId, 'addActiveAvatar', [userId]);
+}
+
+function removeActiveAvatar(streamerId, userId) {
+  return proxyCall(streamerId, 'removeActiveAvatar', [userId]);
+}
+
+function finishRace(streamerId, ...args) {
+  return proxyCall(streamerId, 'finishRace', args, true);
+}
+
+function finishFoodGame(streamerId, ...args) {
+  return proxyCall(streamerId, 'finishFoodGame', args, true);
+}
+
+function startRace(streamerId, ...args) {
+  return proxyCall(streamerId, 'startRace', args);
+}
+
+function startFoodGame(streamerId, ...args) {
+  return proxyCall(streamerId, 'startFoodGame', args);
+}
+
+function checkFoodGameCommand(streamerId, ...args) {
+  return proxyCall(streamerId, 'checkFoodGameCommand', args, true);
+}
+
+function checkFoodGameCheering(streamerId, ...args) {
+  return proxyCall(streamerId, 'checkFoodGameCheering', args, true);
+}
+
+function checkCarrotCollisions(streamerId, ...args) {
+  return proxyCall(streamerId, 'checkCarrotCollisions', args, true);
+}
+
+function spawnCarrot(streamerId, ...args) {
+  return proxyCall(streamerId, 'spawnCarrot', args, true);
+}
+
+function joinFoodGame(streamerId, ...args) {
+  return proxyCall(streamerId, 'joinFoodGame', args, true);
+}
+
+function startFoodGameCountdown(streamerId, ...args) {
+  return proxyCall(streamerId, 'startFoodGameCountdown', args, true);
+}
+
+function startFoodGameMonitoring(streamerId, ...args) {
+  return proxyCall(streamerId, 'startFoodGameMonitoring', args, true);
+}
+
+function setAvatarTimeoutSeconds(streamerId, seconds) {
+  return proxyCall(streamerId, 'setAvatarTimeoutSeconds', [seconds], true);
+}
+
+function getAvatarTimeoutSeconds(streamerId) {
+  return proxyCall(streamerId, 'getAvatarTimeoutSeconds', [], true);
+}
+
+function startRacePlan(streamerId, ...args) {
+  return proxyCall(streamerId, 'startRacePlan', args);
+}
+
+function joinRacePlan(streamerId, ...args) {
+  return proxyCall(streamerId, 'joinRacePlan', args);
+}
+
+function checkRacePlanCommand(streamerId, ...args) {
+  return proxyCall(streamerId, 'checkRacePlanCommand', args, true);
+}
+
+function checkRacePlanCheering(streamerId, ...args) {
+  return proxyCall(streamerId, 'checkRacePlanCheering', args, true);
+}
+
+function spawnObstacle(streamerId, ...args) {
+  return proxyCall(streamerId, 'spawnObstacle', args, true);
+}
+
+function checkRacePlanCollisions(streamerId, ...args) {
+  return proxyCall(streamerId, 'checkRacePlanCollisions', args, true);
+}
+
+function handleRacePlanCollision(streamerId, ...args) {
+  return proxyCall(streamerId, 'handleRacePlanCollision', args, true);
+}
+
+function finishRacePlan(streamerId, ...args) {
+  return proxyCall(streamerId, 'finishRacePlan', args, true);
+}
+
+function setAvatarMetrics(streamerId, ...args) {
+  return proxyCall(streamerId, 'setAvatarMetrics', args, true);
+}
+
+function getGame(streamerId) {
+  const instance = getExistingInstance(streamerId);
+  return instance ? instance.Game : null;
+}
+
+function getRacePlanState(streamerId) {
+  const instance = getExistingInstance(streamerId);
+  return instance ? instance.racePlanState : null;
+}
+
+module.exports = {
+  ensureBotFor,
+  stopBot,
+  status,
+  getBotClient,
+  getBotChannel,
+  addActiveAvatar,
+  removeActiveAvatar,
+  finishRace,
+  finishFoodGame,
+  startRace,
+  startFoodGame,
+  checkFoodGameCommand,
+  checkFoodGameCheering,
+  checkCarrotCollisions,
+  spawnCarrot,
+  joinFoodGame,
+  startFoodGameCountdown,
+  startFoodGameMonitoring,
+  setAvatarTimeoutSeconds,
+  getAvatarTimeoutSeconds,
+  startRacePlan,
+  joinRacePlan,
+  checkRacePlanCommand,
+  checkRacePlanCheering,
+  spawnObstacle,
+  checkRacePlanCollisions,
+  handleRacePlanCollision,
+  finishRacePlan,
+  setAvatarMetrics,
+  getGame,
+  getRacePlanState
+};

--- a/services/state/overlay.js
+++ b/services/state/overlay.js
@@ -1,0 +1,249 @@
+const { getStreamerOverlayState, setStreamerOverlayState } = require('../../db');
+
+class PersistentSet extends Set {
+  constructor(iterable, onChange) {
+    super(iterable);
+    this.onChange = onChange;
+  }
+
+  add(value) {
+    const sizeBefore = this.size;
+    super.add(value);
+    if (this.size !== sizeBefore) {
+      this.onChange();
+    }
+    return this;
+  }
+
+  delete(value) {
+    const existed = super.delete(value);
+    if (existed) {
+      this.onChange();
+    }
+    return existed;
+  }
+
+  clear() {
+    if (this.size > 0) {
+      super.clear();
+      this.onChange();
+    }
+  }
+}
+
+class PersistentMap extends Map {
+  constructor(iterable, onChange) {
+    super(iterable);
+    this.onChange = onChange;
+  }
+
+  set(key, value) {
+    const had = this.has(key);
+    const prev = had ? super.get(key) : undefined;
+    super.set(key, value);
+    if (!had || prev !== value) {
+      this.onChange();
+    }
+    return this;
+  }
+
+  delete(key) {
+    const existed = super.delete(key);
+    if (existed) {
+      this.onChange();
+    }
+    return existed;
+  }
+
+  clear() {
+    if (this.size > 0) {
+      super.clear();
+      this.onChange();
+    }
+  }
+}
+
+function toArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (value instanceof Set) return Array.from(value);
+  if (typeof value === 'object') return Object.values(value);
+  return [];
+}
+
+function toEntries(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (value instanceof Map) return Array.from(value.entries());
+  if (typeof value === 'object') return Object.entries(value);
+  return [];
+}
+
+function createOverlayState(streamerId) {
+  if (!streamerId) {
+    throw new Error('streamerId is required to create overlay state');
+  }
+
+  let persistTimer = null;
+  const raw = getStreamerOverlayState(streamerId) || {};
+
+  const overlayState = {};
+
+  function persistNow() {
+    const serialized = serializeState();
+    setStreamerOverlayState(streamerId, serialized);
+  }
+
+  function schedulePersist() {
+    if (persistTimer) return;
+    persistTimer = setTimeout(() => {
+      persistTimer = null;
+      persistNow();
+    }, 200);
+  }
+
+  const makeSet = data => new PersistentSet(toArray(data), schedulePersist);
+  const makeMap = data => new PersistentMap(toEntries(data), schedulePersist);
+
+  function restoreRaceState(data = {}) {
+    return {
+      isActive: !!data.isActive,
+      participants: makeSet(data.participants),
+      participantNames: makeMap(data.participantNames),
+      positions: makeMap(data.positions),
+      speeds: makeMap(data.speeds),
+      modifiers: makeMap(data.modifiers),
+      maxParticipants: Number.isFinite(data.maxParticipants) ? data.maxParticipants : 10,
+      countdown: Number.isFinite(data.countdown) ? data.countdown : 0,
+      raceStarted: !!data.raceStarted,
+      raceFinished: !!data.raceFinished,
+      winner: data.winner ?? null,
+      speedModifiers: makeMap(data.speedModifiers),
+      startTime: data.startTime ?? null
+    };
+  }
+
+  function restoreFoodGameState(data = {}) {
+    return {
+      isActive: !!data.isActive,
+      participants: makeSet(data.participants),
+      participantNames: makeMap(data.participantNames),
+      scores: makeMap(data.scores),
+      directions: makeMap(data.directions),
+      speedModifiers: makeMap(data.speedModifiers),
+      carrots: Array.isArray(data.carrots) ? data.carrots : [],
+      gameStarted: !!data.gameStarted,
+      gameFinished: !!data.gameFinished,
+      startTime: data.startTime ?? null,
+      winner: data.winner ?? null
+    };
+  }
+
+  function restorePlaneGame(data = {}) {
+    return {
+      isActive: !!data.isActive,
+      gameFinished: !!data.gameFinished,
+      players: makeMap(data.players),
+      obstacles: Array.isArray(data.obstacles) ? data.obstacles : [],
+      lanes: Array.isArray(data.lanes) && data.lanes.length ? data.lanes : [0, 1, 2],
+      maxLives: Number.isFinite(data.maxLives) ? data.maxLives : 3
+    };
+  }
+
+  function restoreRacePlanState(data = {}) {
+    return {
+      isActive: !!data.isActive,
+      participants: makeSet(data.participants),
+      participantNames: makeMap(data.participantNames),
+      positions: makeMap(data.positions),
+      levels: makeMap(data.levels),
+      lives: makeMap(data.lives),
+      obstacles: Array.isArray(data.obstacles) ? data.obstacles : [],
+      gameStarted: !!data.gameStarted,
+      gameFinished: !!data.gameFinished,
+      startTime: data.startTime ?? null,
+      winner: data.winner ?? null,
+      maxParticipants: Number.isFinite(data.maxParticipants) ? data.maxParticipants : 8,
+      trackWidth: Number.isFinite(data.trackWidth) ? data.trackWidth : 1200
+    };
+  }
+
+  overlayState.activeAvatars = makeSet(raw.activeAvatars);
+  overlayState.avatarLastActivity = makeMap(raw.avatarLastActivity);
+  overlayState.avatarStates = makeMap(raw.avatarStates);
+  overlayState.avatarTimeoutSeconds = Number.isFinite(raw.avatarTimeoutSeconds) ? raw.avatarTimeoutSeconds : 300;
+  overlayState.raceState = restoreRaceState(raw.raceState);
+  overlayState.foodGameState = restoreFoodGameState(raw.foodGameState);
+  overlayState.planeGame = restorePlaneGame(raw.planeGame);
+  overlayState.racePlanState = restoreRacePlanState(raw.racePlanState);
+  overlayState.avatarMetrics = makeMap(raw.avatarMetrics);
+
+  function serializeState() {
+    return {
+      activeAvatars: Array.from(overlayState.activeAvatars),
+      avatarLastActivity: Array.from(overlayState.avatarLastActivity.entries()),
+      avatarStates: Array.from(overlayState.avatarStates.entries()),
+      avatarTimeoutSeconds: overlayState.avatarTimeoutSeconds,
+      raceState: {
+        isActive: overlayState.raceState.isActive,
+        participants: Array.from(overlayState.raceState.participants),
+        participantNames: Array.from(overlayState.raceState.participantNames.entries()),
+        positions: Array.from(overlayState.raceState.positions.entries()),
+        speeds: Array.from(overlayState.raceState.speeds.entries()),
+        modifiers: Array.from(overlayState.raceState.modifiers.entries()),
+        maxParticipants: overlayState.raceState.maxParticipants,
+        countdown: overlayState.raceState.countdown,
+        raceStarted: overlayState.raceState.raceStarted,
+        raceFinished: overlayState.raceState.raceFinished,
+        winner: overlayState.raceState.winner,
+        speedModifiers: Array.from(overlayState.raceState.speedModifiers.entries()),
+        startTime: overlayState.raceState.startTime
+      },
+      foodGameState: {
+        isActive: overlayState.foodGameState.isActive,
+        participants: Array.from(overlayState.foodGameState.participants),
+        participantNames: Array.from(overlayState.foodGameState.participantNames.entries()),
+        scores: Array.from(overlayState.foodGameState.scores.entries()),
+        directions: Array.from(overlayState.foodGameState.directions.entries()),
+        speedModifiers: Array.from(overlayState.foodGameState.speedModifiers.entries()),
+        carrots: overlayState.foodGameState.carrots,
+        gameStarted: overlayState.foodGameState.gameStarted,
+        gameFinished: overlayState.foodGameState.gameFinished,
+        startTime: overlayState.foodGameState.startTime,
+        winner: overlayState.foodGameState.winner
+      },
+      planeGame: {
+        isActive: overlayState.planeGame.isActive,
+        gameFinished: overlayState.planeGame.gameFinished,
+        players: Array.from(overlayState.planeGame.players.entries()),
+        obstacles: overlayState.planeGame.obstacles,
+        lanes: overlayState.planeGame.lanes,
+        maxLives: overlayState.planeGame.maxLives
+      },
+      racePlanState: {
+        isActive: overlayState.racePlanState.isActive,
+        participants: Array.from(overlayState.racePlanState.participants),
+        participantNames: Array.from(overlayState.racePlanState.participantNames.entries()),
+        positions: Array.from(overlayState.racePlanState.positions.entries()),
+        levels: Array.from(overlayState.racePlanState.levels.entries()),
+        lives: Array.from(overlayState.racePlanState.lives.entries()),
+        obstacles: overlayState.racePlanState.obstacles,
+        gameStarted: overlayState.racePlanState.gameStarted,
+        gameFinished: overlayState.racePlanState.gameFinished,
+        startTime: overlayState.racePlanState.startTime,
+        winner: overlayState.racePlanState.winner,
+        maxParticipants: overlayState.racePlanState.maxParticipants,
+        trackWidth: overlayState.racePlanState.trackWidth
+      },
+      avatarMetrics: Array.from(overlayState.avatarMetrics.entries())
+    };
+  }
+
+  return {
+    state: overlayState,
+    touch: schedulePersist,
+    flush: persistNow
+  };
+}
+
+module.exports = { createOverlayState };


### PR DESCRIPTION
## Summary
- add a persistent overlay/game state store keyed by streamer IDs and back it with SQLite
- hydrate Twitch bot instances from the shared store and keep overlays, avatars, and mini-game state in sync via throttled persistence hooks
- update bot game logic to mark state changes as dirty so concurrent processes share the same view of avatars and races

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e17fdac4832aa7024a67a5473f30